### PR TITLE
v1.5.0

### DIFF
--- a/.github/workflows/code-check.env
+++ b/.github/workflows/code-check.env
@@ -1,4 +1,4 @@
-# Test config.env file as per config.env.example
+# Test .env file as per .env.example
 
 
 # Django settings

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v3.3.0
 
     - name: Copy the test config file
-      run: cp .github/workflows/code-check.env docker/dev/config.env
+      run: cp .github/workflows/code-check.env docker/dev/.env
 
     - name: Run the Test container
       run: docker compose -f docker/dev/compose.yml run test

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Checkout the repository
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v4.2.2
 
     - name: Copy the test config file
       run: cp .github/workflows/code-check.env docker/dev/.env
@@ -24,7 +24,7 @@ jobs:
       run: docker compose -f docker/dev/compose.yml run test
 
     - name: Commit the changes
-      uses: stefanzweifel/git-auto-commit-action@v4.16.0
+      uses: stefanzweifel/git-auto-commit-action@v5.1.0
       with:
         commit_message: Linting
         status_options: '--untracked-files=no' # Should not create new files

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 __pycache__
 
 # Config files
-config.env
+.env
 
 # App "temp" files
 docker/**/db

--- a/app/core/views.py
+++ b/app/core/views.py
@@ -9,10 +9,10 @@ from drf_spectacular.utils import extend_schema
 class PingView(APIView):
     """View that simply replies with a 'pong'."""
 
-    http_method_names = ["get"]
+    http_method_names = ("get",)
 
-    @extend_schema(operation_id="healthcheck")
-    @extend_schema(summary="Healthcheck")
+    @extend_schema(operation_id="ping")
+    @extend_schema(summary="Ping")
     @extend_schema(responses={status.HTTP_200_OK: {"type": "string", "enum": ["pong"]}})
     def get(self, *args: Any, **kwargs: Any) -> Response:
         return Response("pong", status=status.HTTP_200_OK)

--- a/app/extensions/tests/test_utilities.py
+++ b/app/extensions/tests/test_utilities.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from random import shuffle
+from typing import overload
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from uuid import UUID
@@ -133,6 +134,17 @@ class TestTestUtilities(TestCase):
 
     def test_SampleFile_from_file_path(self) -> None:
         """Test the SampleFile `from_file_path` method."""
+
+        @overload
+        def normalize_line_endings(text: str) -> str: ...
+        @overload
+        def normalize_line_endings(text: bytes) -> bytes: ...
+        def normalize_line_endings(text: str | bytes) -> str | bytes:
+            """Make the line endings match regardless of OS."""
+            if isinstance(text, bytes):
+                return text.replace(b"\r", b"")
+            return text.replace("\r", "")
+
         # Read the text file
         example_file_path = Path(__file__).parent / "example.txt"
         expected_name = example_file_path.name
@@ -141,8 +153,8 @@ class TestTestUtilities(TestCase):
         # Create and verify the sample file
         file = SampleFile.from_file_path(str(example_file_path))
         self.assertEqual(expected_name, file.name)
-        self.assertEqual(expected_content.encode(), file.bytes)
-        self.assertEqual(expected_content, file.content)
+        self.assertEqual(normalize_line_endings(expected_content.encode()), normalize_line_endings(file.bytes))
+        self.assertEqual(normalize_line_endings(expected_content), normalize_line_endings(file.content))
 
 
 class TestEnvUtilities(TestCase):

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,7 +1,7 @@
 # TYPES
 # bool: "true", "t" (and variations) and "1" are accepted as True
 # list: values separated by commas (whitespace is stripped)
-# JSON: string that is JSON parseable
+# JSON: string that is JSON parsable
 
 
 # Django settings

--- a/docker/common-services.yml
+++ b/docker/common-services.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17.0-alpine
+    image: postgres:17.4-alpine
     healthcheck :
       test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres" ]
       interval : 5s

--- a/docker/dev/Dockerfile.dev
+++ b/docker/dev/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG PYTHON=python:3.12.7-alpine
+ARG PYTHON=python:3.13.2-alpine
 
 # Building stage +++++++++++++++++++++++++++++++++++++++++
 FROM ${PYTHON} AS builder

--- a/docker/dev/Dockerfile.test
+++ b/docker/dev/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG PYTHON=python:3.12.7-alpine
+ARG PYTHON=python:3.13.2-alpine
 
 # Building stage +++++++++++++++++++++++++++++++++++++++++
 FROM ${PYTHON} AS builder

--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -8,7 +8,7 @@ services:
       service: db
     volumes:
       - ./db:/var/lib/postgresql/data
-    env_file: config.env
+    env_file: .env
 
   app:
     build:
@@ -23,7 +23,7 @@ services:
       - ./media:/media
     ports:
       - "8000:8000"
-    env_file: config.env
+    env_file: .env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -42,7 +42,7 @@ services:
       - ../../typing:/typing
       - ../../pyproject.toml:/pyproject.toml
       - ./coverage:/coverage
-    env_file: config.env
+    env_file: .env
     depends_on:
       db:
         condition: service_healthy

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON=python:3.12.7-alpine
+ARG PYTHON=python:3.13.2-alpine
 
 # Building stage +++++++++++++++++++++++++++++++++++++++++
 FROM ${PYTHON} AS builder

--- a/docker/prod/compose.yml
+++ b/docker/prod/compose.yml
@@ -8,7 +8,7 @@ services:
       service: db
     volumes:
       - ./db:/var/lib/postgresql/data
-    env_file: config.env
+    env_file: .env
 
   app:
     build:
@@ -22,7 +22,7 @@ services:
       - ./media:/media
     ports:
       - "8000:8000"
-    env_file: config.env
+    env_file: .env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Provided by [PedroPerpetua](https://github.com/PedroPerpetua).
 
 
 ## Version
-Currently set up for `python 3.12.7` with `Django 5.1.5` and `Django Rest Framework 3.15.2`.
+Currently set up for `python 3.12.7` with `Django 5.1.6` and `Django Rest Framework 3.15.2`.
 
 
 ## Getting started

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Provided by [PedroPerpetua](https://github.com/PedroPerpetua).
 
 
 ## Version
-Currently set up for `python 3.12.7` with `Django 5.1.6` and `Django Rest Framework 3.15.2`.
+Currently set up for `python 3.13.2` with `Django 5.1.6` and `Django Rest Framework 3.15.2`.
 
 
 ## Getting started

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Run `./make.sh run` to run the dev server.
   - Also includes classes and mixins for views to facilitate working with Users.
   - **NOTE**: The users, by default, have `active=True`. It may be desired to change this behavior.
   - **NOTE**: The simplejwt settings have `UPDATE_LAST_LOGIN: True`. This may hinder performance and may be desired to change this behavior.
-  - **NOTE**: By default, registration trough REST endpoints is disabled. This can be changed in the `config.env` file, or directly in the settings (setting `AUTH_USER_REGISTRATION_ENABLED`).
+  - **NOTE**: By default, registration trough REST endpoints is disabled. This can be changed in the `.env` file, or directly in the settings (setting `AUTH_USER_REGISTRATION_ENABLED`).
 
 ### REST
 - A `/ping` endpoint to check server availability.
@@ -54,13 +54,13 @@ Run `./make.sh run` to run the dev server.
 - Out of the box OpenAPI schema with Swagger support using [DRF Spectacular](https://github.com/tfranzel/drf-spectacular)
   - The schema is made available in the `/schema` endpoint.
   - The Swagger view is made available in the `/schema/swagger` endpoint.
-  - **NOTE**: By default, only admin users can access these endpoints. This can be changed in the `config.env` file, or directly in the settings(setting `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"]`).
+  - **NOTE**: By default, only admin users can access these endpoints. This can be changed in the `.env` file, or directly in the settings(setting `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"]`).
 
 
 ## Configuration
 
 ### Config files
-`config.env` is the main configuration file. It's recommended to use `extensions.utilities.env` functions to extract variables in multiple formats from here. See `config.env.example` for available configurations and more details. This file should be placed in the respective docker folders: `./docker/dev/config.env` and / or `./docker/prod/config.env`.
+`.env` is the main configuration file. It's recommended to use `extensions.utilities.env` functions to extract variables in multiple formats from here. See `.env.example` for available configurations and more details. This file should be placed in the respective docker folders: `./docker/dev/.env` and / or `./docker/prod/.env`.
 
 Other project specific settings can be changed in Django's `settings.py` file like a regular Django project, to better suit your needs.
 

--- a/make.sh
+++ b/make.sh
@@ -78,7 +78,7 @@ admin() {
 }
 
 schema() {
-    log "[$RUNNING_MODE] Generating schmea..."
+    log "[$RUNNING_MODE] Generating schema..."
     $DOCKER_COMMAND run --rm app sh -c "python manage.py spectacular --color --file schema.yml"
     $DOCKER_COMMAND stop
     mv ./app/schema.yml schema.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Django-Rest-Framework-Boilerplate"
 version = "0.0.1"
-requires-python = "== 3.12.7"
+requires-python = "== 3.13.2"
 readme = "README.md"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ exclude_lines = [
     "def __repr__",
     "if TYPE_CHECKING",
     "@overload",
+    "NotImplementedError",
 ]
 omit = [
     "./app/manage.py",

--- a/requirements/boilerplate.dev.requirements.txt
+++ b/requirements/boilerplate.dev.requirements.txt
@@ -1,14 +1,14 @@
 -r boilerplate.requirements.txt
 
 # Linting
-isort == 5.13.2
+isort == 6.0.0
 autoflake == 2.3.1
-black == 24.10.0
-mypy == 1.14.1
+black == 25.1.0
+mypy == 1.15.0
 
 # Testing
-coverage == 7.6.10
+coverage == 7.6.11
 
 # Type hint stubs
-django-stubs == 5.1.2
+django-stubs == 5.1.3
 djangorestframework-stubs == 3.15.2

--- a/requirements/boilerplate.dev.requirements.txt
+++ b/requirements/boilerplate.dev.requirements.txt
@@ -1,14 +1,14 @@
 -r boilerplate.requirements.txt
 
 # Linting
-isort == 6.0.0
+isort == 6.0.1
 autoflake == 2.3.1
 black == 25.1.0
 mypy == 1.15.0
 
 # Testing
-coverage == 7.6.11
+coverage == 7.6.12
 
 # Type hint stubs
 django-stubs == 5.1.3
-djangorestframework-stubs == 3.15.2
+djangorestframework-stubs == 3.15.3

--- a/requirements/boilerplate.requirements.txt
+++ b/requirements/boilerplate.requirements.txt
@@ -1,6 +1,6 @@
 Django == 5.1.6
 djangorestframework == 3.15.2
-djangorestframework-simplejwt == 5.4.0
+djangorestframework-simplejwt == 5.5.0
 drf-standardized-errors[openapi] == 0.14.1
 drf-spectacular[sidecar] == 0.28.0
 django-cors-headers == 4.7.0

--- a/requirements/boilerplate.requirements.txt
+++ b/requirements/boilerplate.requirements.txt
@@ -1,7 +1,7 @@
-Django == 5.1.5
+Django == 5.1.6
 djangorestframework == 3.15.2
 djangorestframework-simplejwt == 5.4.0
 drf-standardized-errors[openapi] == 0.14.1
 drf-spectacular[sidecar] == 0.28.0
-django-cors-headers == 4.6.0
+django-cors-headers == 4.7.0
 psycopg2-binary == 2.9.10


### PR DESCRIPTION
- Bumped Python version to `1.13.2`.
- Bumped github action versions.
- Closed multiple issues.
  - Fixed typo in make;
  - `ping` endpoint doesn't overlap with Healthcheck namings anymore;
  - `test_SampleFile_from_file_path` now ignores line endings;
  - `NotImplementedError is now ignored by coverage;
  - `config.env` renamed to `.env`.
- Upgraded depencencies.