### PR TITLE
v2.2.0

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -122,7 +122,7 @@ DATABASES = {
         "PASSWORD": env.as_string("POSTGRES_PASSWORD"),
         "HOST": env.as_string("POSTGRES_HOST"),
         "PORT": env.as_string("POSTGRES_PORT"),
-    }
+    },
 }
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
@@ -209,18 +209,10 @@ SPECTACULAR_SETTINGS = {
 
 AUTH_USER_MODEL = "users.User"
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
-    },
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 AUTH_USER_REGISTRATION_ENABLED = env.as_bool("AUTH_USER_REGISTRATION_ENABLED", False)
 AUTHENTICATION_BACKENDS = ["users.backends.AuthenticationBackend"]

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -222,8 +222,8 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
-AUTHENTICATION_BACKENDS = ["users.backends.AuthenticationBackend"]
 AUTH_USER_REGISTRATION_ENABLED = env.as_bool("AUTH_USER_REGISTRATION_ENABLED", False)
+AUTHENTICATION_BACKENDS = ["users.backends.AuthenticationBackend"]
 
 
 # Localization settings

--- a/app/core/management/commands/_base_command.py
+++ b/app/core/management/commands/_base_command.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Any
 from django.core.management.base import BaseCommand as DjangoCommand
 from django.core.management.base import OutputWrapper
@@ -16,7 +17,7 @@ class BaseCommand(DjangoCommand):
         _level: int
         INDENTATION = " " * 2  # 2 spaces
 
-        def __init__(self, source: "OutputWrapper | BaseCommand.IndentedOutputWrapper"):
+        def __init__(self, source: OutputWrapper | BaseCommand.IndentedOutputWrapper):
             out_source = source if not isinstance(source, OutputWrapper) else source._out
             super().__init__(out=out_source, ending="")  # type: ignore[arg-type] # Supertype "incompatibility"
             self._level = 1

--- a/app/extensions/admin.py
+++ b/app/extensions/admin.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional
 from django.contrib import admin
 from django.http import HttpRequest
@@ -43,7 +44,7 @@ class BaseAdminSite(admin.AdminSite):
         return ordered_apps
 
 
-object_metadata_fieldset: "tuple[_StrOrPromise | None, _FieldOpts]" = (
+object_metadata_fieldset: tuple[_StrOrPromise | None, _FieldOpts] = (
     _("Object metadata"),
     {"fields": ("id", "is_deleted", "created_at", "updated_at")},
 )

--- a/app/extensions/serializers.py
+++ b/app/extensions/serializers.py
@@ -40,7 +40,9 @@ class NestedPrimaryKeyRelatedFieldSerializerExtension(OpenApiSerializerFieldExte
     target: NestedPrimaryKeyRelatedField
 
     def map_serializer_field(
-        self, auto_schema: AutoSchema, direction: Literal["request", "response"]
+        self,
+        auto_schema: AutoSchema,
+        direction: Literal["request", "response"],
     ) -> dict[str, Any]:
         """
         Override the serialization so that, in the response, we use the field's serializer; and in the request, we use

--- a/app/extensions/tests/test_utilities.py
+++ b/app/extensions/tests/test_utilities.py
@@ -4,7 +4,6 @@ from random import shuffle
 from typing import overload
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
-from uuid import UUID
 import extensions.utilities as utils
 from extensions.utilities import env
 from extensions.utilities.logging import LoggingConfigurationBuilder
@@ -14,15 +13,6 @@ from extensions.utilities.types import JSON
 
 class TestUtilities(TestCase):
     """Test the base utilities provided."""
-
-    def test_jsonify(self) -> None:
-        """Test the `jsonify` function."""
-        data = {"id": UUID(utils.uuid())}
-        json_data = {"id": str(data["id"])}
-        # Compare them before, to check that it would be different
-        self.assertNotEqual(json_data, data)
-        # Compare with the jsonify
-        self.assertEqual(json_data, utils.jsonify(data))
 
     def test_empty(self) -> None:
         """Test the `empty` function."""

--- a/app/extensions/utilities/__init__.py
+++ b/app/extensions/utilities/__init__.py
@@ -1,8 +1,6 @@
-import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, overload
 from uuid import uuid4
-from django.core.serializers.json import DjangoJSONEncoder
 
 
 if TYPE_CHECKING:
@@ -29,18 +27,6 @@ def empty(string: Optional[str]) -> bool:
     if string.strip() == "":
         return True
     return False
-
-
-def jsonify(data: Any) -> JSON:
-    """
-    This function will encode and decode the data passed to it with DjangoJSONEncoder.
-
-    This is useful, for example, to compare Python data and loaded JSON responses. A common use case is to compare
-    serializer data with a response's JSON in a test case; comparing the serializer data directly may yield unexpected
-    results, like UUID fields being considered different between the data and the response, even though they
-    effectively represent the same UUID.
-    """
-    return cast(JSON, json.loads(json.dumps(data, cls=DjangoJSONEncoder)))
 
 
 @overload

--- a/app/extensions/utilities/env.py
+++ b/app/extensions/utilities/env.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 import os
 from typing import TYPE_CHECKING, Optional, TypeVar
@@ -75,7 +76,7 @@ def as_list(var: str, default: Optional[list[str]] = None) -> list[str]:
     return value
 
 
-def as_json(var: str, default: Optional["JSON"] = None) -> "JSON":
+def as_json(var: str, default: Optional[JSON] = None) -> JSON:
     """
     Return the environment variable loaded as a JSON object. If no default value is given and the variable is not set,
     raises KeyError.

--- a/app/extensions/utilities/test.py
+++ b/app/extensions/utilities/test.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 import re
 import requests
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Type, cast
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.db.models import Model
 from django.test import TestCase
+from rest_framework.serializers import BaseSerializer
 from rest_framework.test import APITestCase as DRFAPITestCase
 from extensions.utilities import uuid
 from extensions.utilities.types import JSON
@@ -14,9 +15,6 @@ from extensions.utilities.types import JSON
 
 if TYPE_CHECKING:
     from rest_framework.response import _MonkeyPatchedResponse as Response
-
-else:
-    from rest_framework.response import Response
 
 
 class APITestCase(DRFAPITestCase):
@@ -33,6 +31,20 @@ class APITestCase(DRFAPITestCase):
         except:
             content = str(response.content)
         self.assertEqual(expected_status_code, response.status_code, content)
+
+    def assertResponseData[T: Model](
+        self,
+        expected_instance: T | Iterable[T],
+        serializer: type[BaseSerializer[T]],
+        response: Response,
+    ) -> None:
+        """Assert that the response's data matches the given instance(s) serialized."""
+        data = serializer(
+            # https://github.com/typeddjango/djangorestframework-stubs/issues/260
+            expected_instance,  # type: ignore[arg-type]
+            many=(not isinstance(expected_instance, Model)),
+        ).data
+        self.assertEqual(data, response.json())
 
 
 class AbstractModelTestCase(TestCase):

--- a/app/extensions/utilities/test.py
+++ b/app/extensions/utilities/test.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import re
 import requests
 from pathlib import Path
@@ -132,7 +133,7 @@ class SampleFile(SimpleUploadedFile):
         return self.bytes.decode()
 
     @staticmethod
-    def from_file_path(file_path: str | Path) -> "SampleFile":
+    def from_file_path(file_path: str | Path) -> SampleFile:
         """Generates a SampleFile from a real file, having the same contents."""
         if isinstance(file_path, str):
             file_path = Path(file_path)

--- a/app/extensions/utilities/test.py
+++ b/app/extensions/utilities/test.py
@@ -43,6 +43,8 @@ class APITestCase(DRFAPITestCase):
             # https://github.com/typeddjango/djangorestframework-stubs/issues/260
             expected_instance,  # type: ignore[arg-type]
             many=(not isinstance(expected_instance, Model)),
+            # https://github.com/typeddjango/djangorestframework-stubs/issues/389
+            context={"request": response.wsgi_request},  # type: ignore[attr-defined]
         ).data
         self.assertEqual(data, response.json())
 

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -96,6 +96,7 @@ omit = [
     "./app/asgi.py",
     "./app/wsgi.py",
     "./core/management/commands/_base_command.py",
+    "*/tests/__init__.py",
 ]
 
 [tool.coverage.html]

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Django-Rest-Framework-Boilerplate"
 version = "0.0.1"
-requires-python = "== 3.13.2"
+requires-python = "== 3.13.3"
 readme = "README.md"
 
 

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 
 
 [boilerplate]
-version = "2.1.0"
+version = "2.2.0"
 
 
 [tool.ruff]

--- a/app/users/admin.py
+++ b/app/users/admin.py
@@ -13,15 +13,7 @@ class UserAdmin(BaseUserAdmin):
     search_fields = ("username",)
     ordering = ("created_at",)
 
-    add_fieldsets = (
-        (
-            None,
-            {
-                "classes": ("wide",),
-                "fields": ("username", "password1", "password2"),
-            },
-        ),
-    )
+    add_fieldsets = ((None, {"classes": ("wide",), "fields": ("username", "password1", "password2")}),)
 
     readonly_fields = ("id", "created_at", "updated_at", "last_login")
     fieldsets = (

--- a/app/users/serializers.py
+++ b/app/users/serializers.py
@@ -39,17 +39,5 @@ class UserProfileSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.User
-        # Because more fields can be included in the user, instead exclude all that we know we don't want
-        exclude = (
-            "id",
-            "created_at",
-            "updated_at",
-            "is_deleted",
-            "is_staff",
-            "is_active",
-            "is_superuser",
-            "password",
-            "last_login",
-            "groups",
-            "user_permissions",
-        )
+        fields = ("id", "username", "created_at")
+        extra_kwargs = {"username": {"read_only": True}}

--- a/app/users/tests/test_views.py
+++ b/app/users/tests/test_views.py
@@ -274,7 +274,7 @@ class TestUserChangePasswordView(APITestCase):
                         "code": "password_too_short",
                         "detail": "This password is too short. It must contain at least 8 characters.",
                         "attr": "non_field_errors",
-                    }
+                    },
                 ],
             },
             res.json(),

--- a/app/users/tests/test_views.py
+++ b/app/users/tests/test_views.py
@@ -24,7 +24,7 @@ class TestUserRegisterView(APITestCase):
         self.assertResponseStatusCode(status.HTTP_201_CREATED, res)
         self.assertEqual(original_count + 1, User.objects.count())
         created_user = User.objects.get(id=res.data["id"])
-        self.assertEqual(serializers.UserRegisterSerializer(created_user).data, res.json())
+        self.assertResponseData(created_user, serializers.UserRegisterSerializer, res)
         # Make sure the User was created properly
         self.assertEqual(created_user.username, payload["username"])
         self.assertTrue(created_user.check_password(payload["password"]))
@@ -144,7 +144,7 @@ class TestUserWhoamiView(APITestCase):
         res = self.client.get(self.URL)
         # Verify the response
         self.assertResponseStatusCode(status.HTTP_200_OK, res)
-        self.assertEqual(serializers.UserWhoamiSerializer(user).data, res.json())
+        self.assertResponseData(user, serializers.UserWhoamiSerializer, res)
 
     def test_authentication_required(self) -> None:
         """Test that the Whoami endpoint requires an authenticated user."""
@@ -169,7 +169,7 @@ class TestUserProfileView(APITestCase):
         res = self.client.get(self.URL)
         # verify the response
         self.assertResponseStatusCode(status.HTTP_200_OK, res)
-        self.assertEqual(serializers.UserProfileSerializer(self.user).data, res.json())
+        self.assertResponseData(self.user, serializers.UserProfileSerializer, res)
 
     def test_retrieve_authentication_required(self) -> None:
         """Test that the User needs to be logged in to retrieve their profile."""

--- a/app/users/tests/test_views.py
+++ b/app/users/tests/test_views.py
@@ -1,3 +1,4 @@
+from typing import Any
 from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
@@ -183,15 +184,16 @@ class TestUserProfileView(APITestCase):
     def test_update_success(self) -> None:
         """Test successfully updating the User's profile."""
         for method in [self.client.patch, self.client.put]:
-            with self.subTest(message="Test updating User profile without being logged in.", value=method.__name__):
-                payload = {"username": f"_username_updated_{method.__name__}"}
+            with self.subTest(message="Test updating User profile successfully.", value=method.__name__):
+                # The default UserProfileSerializer has no fields that can be updated; so we test for empty payload
+                payload: dict[str, Any] = {}
                 # Make the call
                 res = method(self.URL, data=payload)
                 # Verify the response
                 self.assertResponseStatusCode(status.HTTP_200_OK, res)
-                # Make sure the username changed
+                # Verify any field changes
                 self.user.refresh_from_db()
-                self.assertEqual(payload["username"], self.user.username)
+                # ...
 
     def test_update_authentication_required(self) -> None:
         """Test that the User needs to be logged in to update their profile."""

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON=python:3.13.2-alpine
+ARG PYTHON=python:3.13.3-alpine
 
 # Building stage +++++++++++++++++++++++++++++++++++++++++
 FROM ${PYTHON} AS builder

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -5,6 +5,8 @@ FROM ${PYTHON} AS builder
 
 # Add build-time dependencies ----------------------------
 RUN apk update
+# For psycopg2
+RUN apk add build-base libpq libpq-dev
 
 # Create venv --------------------------------------------
 RUN python3 -m venv --upgrade-deps /venv
@@ -22,6 +24,8 @@ ENV RUFF_NO_CACHE=true
 
 # Add runtime dependencies -------------------------------
 RUN apk update
+# For psycopg2
+RUN apk add --no-cache libpq
 
 # Copy Python environment --------------------------------
 COPY --from=builder /venv/ /venv

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON=python:3.13.2-alpine
+ARG PYTHON=python:3.13.3-alpine
 
 # Building stage +++++++++++++++++++++++++++++++++++++++++
 FROM ${PYTHON} AS builder

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -5,6 +5,8 @@ FROM ${PYTHON} AS builder
 
 # Add build-time dependencies ----------------------------
 RUN apk update
+# For psycopg2
+RUN apk add build-base libpq libpq-dev
 
 # Create venv --------------------------------------------
 RUN python3 -m venv --upgrade-deps /venv
@@ -25,6 +27,8 @@ ENV PYTHONUNBUFFERED 1
 
 # Add runtime dependencies -------------------------------
 RUN apk update
+# For psycopg2
+RUN apk add --no-cache libpq
 
 # Setup Supervisor + nginx -------------------------------
 RUN apk --no-cache add nginx

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Provided by [PedroPerpetua](https://github.com/PedroPerpetua).
 
 
 ## Version
-Currently set up for `python 3.13.2` with `Django 5.1.7` and `Django Rest Framework 3.15.2`.
+Currently set up for `python 3.13.3` with `Django 5.2.0` and `Django Rest Framework 3.16.0`.
 
 
 ## Getting started

--- a/make.py
+++ b/make.py
@@ -3,6 +3,7 @@ import requests
 import shutil
 import subprocess
 import tomllib
+import webbrowser
 import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -405,6 +406,16 @@ def test(skip_lint: bool, lint_only: bool, test_suite: str) -> None:
 
 
 @cli.command
+def open_coverage() -> None:
+    """Open the coverage index file on a new tab in your browser."""
+    coverage_file = BASE_DIR / "docker" / "dev" / "coverage" / "index.html"
+    if not coverage_file.exists():
+        error("No coverage file found. Please run the test command first.")
+        raise click.Abort()
+    webbrowser.open(f"file://{coverage_file.resolve()}", new=2)
+
+
+@cli.command
 @production_opt
 @click.argument("commands", nargs=-1)
 def command(production: bool, commands: tuple[str, ...]) -> None:
@@ -438,6 +449,7 @@ def clean(production: bool, all: bool, yes: bool) -> None:
             path = base_path / folder_name
             if path.exists():
                 shutil.rmtree(path.resolve())
+        success("All data cleared.", bold=True)
 
 
 @cli.command

--- a/requirements/boilerplate.dev.requirements.txt
+++ b/requirements/boilerplate.dev.requirements.txt
@@ -4,7 +4,7 @@
 click == 8.1.8
 
 # Linting
-ruff == 0.11.4
+ruff == 0.11.5
 mypy == 1.15.0
 
 # Type hint stubs

--- a/requirements/boilerplate.dev.requirements.txt
+++ b/requirements/boilerplate.dev.requirements.txt
@@ -4,7 +4,7 @@
 click == 8.1.8
 
 # Linting
-ruff == 0.11.0
+ruff == 0.11.4
 mypy == 1.15.0
 
 # Type hint stubs
@@ -12,4 +12,4 @@ django-stubs == 5.1.3
 djangorestframework-stubs == 3.15.3
 
 # Testing
-coverage == 7.7.0
+coverage == 7.8.0

--- a/requirements/boilerplate.requirements.txt
+++ b/requirements/boilerplate.requirements.txt
@@ -1,5 +1,5 @@
-Django == 5.1.7
-djangorestframework == 3.15.2
+Django == 5.2.0
+djangorestframework == 3.16.0
 djangorestframework-simplejwt == 5.5.0
 drf-standardized-errors[openapi] == 0.14.1
 drf-spectacular[sidecar] == 0.28.0

--- a/requirements/boilerplate.requirements.txt
+++ b/requirements/boilerplate.requirements.txt
@@ -4,4 +4,4 @@ djangorestframework-simplejwt == 5.5.0
 drf-standardized-errors[openapi] == 0.14.1
 drf-spectacular[sidecar] == 0.28.0
 django-cors-headers == 4.7.0
-psycopg2-binary == 2.9.10
+psycopg2 == 2.9.10


### PR DESCRIPTION
- Fixed multiple issues:
  - Coverage now ignores the `__init__.py` files in test directories (where the `sample_x` functions are placed);
  - Jsonify has been removed - see issue #71 for more information;
  - Login schema now has a 401 response;
  - UserProfileView updates now are more strict by default;
  - Psycopg2 uses the default build instead of the binary (as recommended by the library documentation).
 - Small formatting adjusments;
 - Small improvements to testing;
 - Upgraded dependencies.