### PR TITLE
v2.8.0

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -26,8 +26,8 @@ CONSTANCE_CONFIG = OrderedDict(
     [
         ("AUTH_USER_REGISTRATION_ENABLED", (False, _("Enable regular user registration"), bool)),
         ("OPENAPI_TITLE", ("API", _("OpenAPI schema title"), str)),
-        ("OPENAPI_DESCRIPTION", ("", _("OpenAPI schema description"), str)),
         ("OPENAPI_VERSION", ("v0.0.1", _("OpenAPI schema version"), str)),
+        ("OPENAPI_DESCRIPTION", ("", _("OpenAPI schema description"), str)),
         ("OPENAPI_ADMIN_ONLY", (True, _("Only allow admins to have access to the schema"), bool)),
     ]
 )
@@ -130,7 +130,7 @@ logger_config = (
     .add_logger("core", ["debug_handler", "core_handler"], level=LOG_LEVEL, propagate=False)
 )
 
-if "gunicorn" in env.as_string("SERVER_SOFTWARE", "").lower():
+if "gunicorn" in env.as_string("SERVER_SOFTWARE", "").lower():  # pragma: no cover
     # If we're running under gunicorn, add it to our logger
     logger_config.add_file_handler("gunicorn_handler", LOG_FOLDER / "gunicorn.log")
     logger_config.add_logger(

--- a/app/extensions/serializers.py
+++ b/app/extensions/serializers.py
@@ -1,5 +1,6 @@
 from typing import Any, Iterable, Literal, Optional, Protocol, overload
 from django.db.models import Model, QuerySet
+from rest_framework.relations import PKOnlyObject
 from rest_framework.serializers import ModelSerializer, PrimaryKeyRelatedField
 from drf_spectacular.extensions import OpenApiSerializerFieldExtension
 from drf_spectacular.openapi import AutoSchema
@@ -162,7 +163,7 @@ class NestedPrimaryKeyRelatedField[_MT: Model](FilteredPrimaryKeyRelatedField[_M
         kwargs.setdefault("queryset", serializer.Meta.model._default_manager.all())  # type: ignore[attr-defined]
         super().__init__(**kwargs)
 
-    def to_representation(self, obj: _MT) -> Any:
+    def to_representation(self, obj: _MT | PKOnlyObject) -> Any:
         qs = self.get_queryset()
         # Because we set the default queryset in the `__init__` we should always have a QuerySet here
         assert isinstance(qs, QuerySet)

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "Django-Rest-Framework-Boilerplate"
 version = "0.0.1"
-requires-python = "== 3.13.7"
+requires-python = "== 3.14.0"
 readme = "README.md"
 
 
 [boilerplate]
-version = "2.7.0"
+version = "2.8.0"
 
 
 [tool.ruff]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "Django-Rest-Framework-Boilerplate-CLI"
 version = "1.0.0"
-requires-python = "== 3.13.7"
+requires-python = "== 3.14.0"
 
 [tool.ruff]
 cache-dir = "/dev/null"

--- a/docker/common-services.yml
+++ b/docker/common-services.yml
@@ -1,7 +1,7 @@
 services:
   db:
     image: postgres:17.5-alpine
-    healthcheck :
+    healthcheck:
       test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres" ]
       interval : 5s
       timeout : 2s

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON=python:3.13.7-alpine
+ARG PYTHON=python:3.14.0-alpine
 
 # Building stage +++++++++++++++++++++++++++++++++++++++++
 FROM ${PYTHON} AS builder
@@ -6,7 +6,7 @@ FROM ${PYTHON} AS builder
 # Add build-time dependencies ----------------------------
 RUN apk update
 # For psycopg2
-RUN apk add build-base libpq libpq-dev
+RUN apk add --no-cache build-base libpq libpq-dev
 
 # Create venv --------------------------------------------
 RUN python3 -m venv --upgrade-deps /venv

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON=python:3.13.7-alpine
+ARG PYTHON=python:3.14.0-alpine
 
 # Building stage +++++++++++++++++++++++++++++++++++++++++
 FROM ${PYTHON} AS builder
@@ -6,7 +6,7 @@ FROM ${PYTHON} AS builder
 # Add build-time dependencies ----------------------------
 RUN apk update
 # For psycopg2
-RUN apk add build-base libpq libpq-dev
+RUN apk add --no-cache build-base libpq libpq-dev
 
 # Create venv --------------------------------------------
 RUN python3 -m venv --upgrade-deps /venv

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Provided by [PedroPerpetua](https://github.com/PedroPerpetua).
 
 
 ## Version
-Currently set up for `python 3.13.7` with `Django 5.2.7` and `Django Rest Framework 3.16.1`.
+Currently set up for `python 3.14.0` with `Django 5.2.8` and `Django Rest Framework 3.16.1`.
 
 
 ## Getting started

--- a/docs/boilerplate_CHANGELOG.md
+++ b/docs/boilerplate_CHANGELOG.md
@@ -42,17 +42,13 @@ This CHANGELOG was only adopted from v2.6.0 forward, so previous release are **n
 - Improved Docker builds.
 
 ### Dependencies
-- `python`: `3.13.5` -> `3.13.7`.
-- `Django`: `5.2.5` -> `5.2.7`.
-- `django-cors-headers` `4.7.0` -> `4.9.0`.
+- `Django`: `5.2.6` -> `5.2.7`.
+- `django-cors-headers` `4.8.0` -> `4.9.0`.
 - `click`: `8.2.1` -> `8.3.0`.
-- `ruff`: `0.12.8` -> `0.13.3`.
-- `mypy`: `1.17.1` -> `1.18.2`.
-- `django-stubs`: `5.2.2` -> `5.2.5`.
+- `ruff`: `0.13.0` -> `0.13.3`.
+- `mypy`: `1.18.1` -> `1.18.2`.
 - `djangorestframework-stubs`: `3.16.2` -> `3.16.4`.
-- `types-docker`: `7.1.0.20250809` -> `7.1.0.20250916`.
-- `pytest`: `8.4.1` -> `8.4.2`.
-- `pytest-cov`: `6.2.1` -> `7.0.0`.
+- `types-docker`: `7.1.0.20250907` -> `7.1.0.20250916`.
 
 
 ## [2.6.1] - 2025-09-14

--- a/docs/boilerplate_CHANGELOG.md
+++ b/docs/boilerplate_CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This CHANGELOG was only adopted from v2.6.0 forward, so previous release are **not** documented. Maybe in the future they'll be added.
 
 
+## [2.8.0] - 2025-11-15
+
+### Changed
+- Reordered Constance settings to an order that makes more sense.
+
+### Fixed
+- Fixed some Docker syntax inconsistencies.
+
+### Dependencies
+- `python`: `3.13.7` -> `3.14.0`.
+- `Django`: `5.2.7` -> `5.2.8`.
+- `psycopg2`: `2.9.10` -> `2.9.11`.
+- `drf-spectacular`: `0.28.0` -> `0.29.0`.
+- `django-constance`: `4.3.2` -> `4.3.4`.
+- `ruff`: `0.13.3` -> `0.14.5`.
+- `django-stubs`: `5.2.5` -> `5.2.7`.
+- `djangorestframework-stubs`: `3.16.4` -> `3.16.5`.
+- `types-docker`: `7.1.0.20250916` -> `7.1.0.20251009`.
+- `pytest`: `8.4.2` -> `9.0.1`.
+- `pytest-subtest`: `0.14.2` -> `0.15.0`.
+
+
 ## [2.7.0] - 2025-10-05
 
 ### Changed
@@ -20,7 +42,7 @@ This CHANGELOG was only adopted from v2.6.0 forward, so previous release are **n
 - Improved Docker builds.
 
 ### Dependencies
-- `python`: `3.1.5` -> `3.1.7`.
+- `python`: `3.13.5` -> `3.13.7`.
 - `Django`: `5.2.5` -> `5.2.7`.
 - `django-cors-headers` `4.7.0` -> `4.9.0`.
 - `click`: `8.2.1` -> `8.3.0`.
@@ -36,7 +58,7 @@ This CHANGELOG was only adopted from v2.6.0 forward, so previous release are **n
 ## [2.6.1] - 2025-09-14
 
 ### Dependencies
-- Python version: `3.13.5` -> `3.13.7`.
+- `python`: `3.13.5` -> `3.13.7`.
 - `Django`: `5.2.5` -> `5.2.6`.
 - `django-cors-headers`: `4.7.0` -> `4.8.0`.
 - `ruff`: `0.12.8` -> `0.13.0`.

--- a/requirements/boilerplate.dev.requirements.txt
+++ b/requirements/boilerplate.dev.requirements.txt
@@ -5,17 +5,17 @@ click == 8.3.0
 docker == 7.1.0
 
 # Linting
-ruff == 0.13.3
+ruff == 0.14.5
 mypy == 1.18.2
 
 # Type hint stubs
-django-stubs == 5.2.5
-djangorestframework-stubs == 3.16.4
-types-docker == 7.1.0.20250916
+django-stubs == 5.2.7
+djangorestframework-stubs == 3.16.5
+types-docker == 7.1.0.20251009
 
 # Testing
-pytest == 8.4.2
-pytest-subtests == 0.14.2
+pytest == 9.0.1
+pytest-subtests == 0.15.0
 pytest-cov == 7.0.0
 pytest-xdist == 3.8.0
 pytest-django == 4.11.1

--- a/requirements/boilerplate.requirements.txt
+++ b/requirements/boilerplate.requirements.txt
@@ -1,8 +1,8 @@
-Django == 5.2.7
-psycopg2 == 2.9.10
+Django == 5.2.8
+psycopg2 == 2.9.11
 django-cors-headers == 4.9.0
 djangorestframework == 3.16.1
 djangorestframework-simplejwt == 5.5.1
 drf-standardized-errors[openapi] == 0.15.0
-drf-spectacular[sidecar] == 0.28.0
-django-constance == 4.3.2
+drf-spectacular[sidecar] == 0.29.0
+django-constance == 4.3.4


### PR DESCRIPTION
From the [changelog](./docs/boilerplate_CHANGELOG.md#280---2025-11-15):
### Changed
- Reordered Constance settings to an order that makes more sense.

### Fixed
- Fixed some Docker syntax inconsistencies.

### Dependencies
- `python`: `3.13.7` -> `3.14.0`.
- `Django`: `5.2.7` -> `5.2.8`.
- `psycopg2`: `2.9.10` -> `2.9.11`.
- `drf-spectacular`: `0.28.0` -> `0.29.0`.
- `django-constance`: `4.3.2` -> `4.3.4`.
- `ruff`: `0.13.3` -> `0.14.5`.
- `django-stubs`: `5.2.5` -> `5.2.7`.
- `djangorestframework-stubs`: `3.16.4` -> `3.16.5`.
- `types-docker`: `7.1.0.20250916` -> `7.1.0.20251009`.
- `pytest`: `8.4.2` -> `9.0.1`.
- `pytest-subtest`: `0.14.2` -> `0.15.0`.